### PR TITLE
Rework Parser Generation Logic

### DIFF
--- a/metricmonitor.go
+++ b/metricmonitor.go
@@ -1,6 +1,11 @@
 package ddqp
 
-import "github.com/alecthomas/participle/v2/lexer"
+import (
+	"strings"
+
+	"github.com/alecthomas/participle/v2"
+	"github.com/alecthomas/participle/v2/lexer"
+)
 
 type MetricMonitor struct {
 	Pos lexer.Position
@@ -10,4 +15,30 @@ type MetricMonitor struct {
 	MetricQuery      *MetricQuery `@@`
 	Comparator       string       `@( ">" | ">" "=" | "<" | "<" "=" )`
 	Threshold        float64      `@(Int|Float)`
+}
+
+// NewMetricMonitorParser returns a Parser which is capable of interpretting
+// a metric query.
+func NewMetricMonitorParser() Parser {
+	mmp := &MetricMonitorParser{
+		parser: participle.MustBuild[MetricMonitor](
+			participle.Lexer(lex),
+			participle.Unquote("String"),
+		),
+	}
+
+	return mmp
+}
+
+// MetricQueryParser is parser returned when calling NewMetricQueryParser.
+type MetricMonitorParser struct {
+	parser *participle.Parser[MetricMonitor]
+}
+
+// Parse sanitizes the query string and returns the AST and any error.
+func (mmp *MetricMonitorParser) Parse(query string) (ParsedResponse, error) {
+	// the parser doesn't handle queries that are split up across multiple lines
+	sanitized := strings.ReplaceAll(query, "\n", "")
+	// return the raw parsed outpu
+	return mmp.parser.ParseString("", sanitized)
 }

--- a/metricmonitor_test.go
+++ b/metricmonitor_test.go
@@ -37,7 +37,7 @@ func Test_MetricMonitor(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ast, err := parser.ParseString("", tt.query)
+			ast, err := parser.Parse(tt.query)
 			if (err != nil) != tt.wantErr {
 				require.NoError(t, err)
 			}

--- a/metricquery.go
+++ b/metricquery.go
@@ -62,7 +62,7 @@ type MetricQueryParser struct {
 }
 
 // Parse sanitizes the query string and returns the AST and any error.
-func (mqp *MetricQueryParser) Parse(query string) (*MetricQuery, error) {
+func (mqp *MetricQueryParser) Parse(query string) (ParsedResponse, error) {
 	// the parser doesn't handle queries that are split up across multiple lines
 	sanitized := strings.ReplaceAll(query, "\n", "")
 	// return the raw parsed outpu

--- a/metricquery_test.go
+++ b/metricquery_test.go
@@ -75,7 +75,7 @@ func Test_MetricQuery(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ast, err := parser.ParseString("", tt.query)
+			ast, err := parser.Parse(tt.query)
 			if (err != nil) != tt.wantErr {
 				require.NoError(t, err)
 			}

--- a/parser.go
+++ b/parser.go
@@ -1,11 +1,11 @@
 package ddqp
 
 import (
-	"github.com/alecthomas/participle/v2"
 	"github.com/alecthomas/participle/v2/lexer"
 )
 
 var (
+	// This is the primary lexer for all parsers
 	// nolint:govet
 	lex = lexer.MustSimple([]lexer.SimpleRule{
 		{"Comment", `(?i)rem[^\n]*`},
@@ -19,13 +19,9 @@ var (
 	})
 )
 
-func NewMetricMonitorParser() *participle.Parser[MetricMonitor] {
-	return participle.MustBuild[MetricMonitor](
-		participle.Lexer(lex),
-		participle.Unquote("String"),
-	)
+type Parser interface {
+	Parse(string) (ParsedResponse, error)
 }
 
-type Parser interface {
-	Parse(string) (*MetricQuery, error)
+type ParsedResponse interface {
 }

--- a/parser.go
+++ b/parser.go
@@ -19,16 +19,13 @@ var (
 	})
 )
 
-func NewMetricQueryParser() *participle.Parser[MetricQuery] {
-	return participle.MustBuild[MetricQuery](
-		participle.Lexer(lex),
-		participle.Unquote("String"),
-	)
-}
-
 func NewMetricMonitorParser() *participle.Parser[MetricMonitor] {
 	return participle.MustBuild[MetricMonitor](
 		participle.Lexer(lex),
 		participle.Unquote("String"),
 	)
+}
+
+type Parser interface {
+	Parse(string) (*MetricQuery, error)
 }


### PR DESCRIPTION
# Purpose

Updating the parser to:

1. Be more specific to each unit being parsed
2. To be more generic 
