### PR TITLE
Preserve Filter Separator

### DIFF
--- a/metricexpression.go
+++ b/metricexpression.go
@@ -30,22 +30,22 @@ type ExprValue struct {
 	Number        *float64          `|  @(Float|Int)`
 }
 
-func (ex *ExprValue) GetQueries() []string {
+func (expr *ExprValue) GetQueries() []string {
 	strs := []string{}
-	if ex.Subexpression != nil {
-		m := ex.Subexpression.GetQueries()
+	if expr.Subexpression != nil {
+		m := expr.Subexpression.GetQueries()
 		for _, v := range m {
 			strs = append(strs, v)
 		}
 		return strs
 	}
 
-	if ex.MetricQuery != nil {
-		strs = append(strs, ex.MetricQuery.String())
+	if expr.MetricQuery != nil {
+		strs = append(strs, expr.MetricQuery.String())
 		return strs
 	}
 
-	return []string{fmt.Sprintf("%d", ex.Number)}
+	return []string{fmt.Sprintf("%d", expr.Number)}
 }
 
 type Factor struct {
@@ -138,14 +138,14 @@ func (o Operator) String() string {
 	panic("unsupported operator")
 }
 
-func (v *ExprValue) String() string {
-	if v.Number != nil {
-		return fmt.Sprintf("%g", *v.Number)
+func (expr *ExprValue) String() string {
+	if expr.Number != nil {
+		return fmt.Sprintf("%g", *expr.Number)
 	}
-	if v.MetricQuery != nil {
-		return v.MetricQuery.String()
+	if expr.MetricQuery != nil {
+		return expr.MetricQuery.String()
 	}
-	return "(" + v.Subexpression.String() + ")"
+	return "(" + expr.Subexpression.String() + ")"
 }
 
 func (f *Factor) String() string {
@@ -169,9 +169,9 @@ func (o *OpTerm) String() string {
 	return fmt.Sprintf("%s %s", o.Operator, o.Term)
 }
 
-func (e *MetricExpression) String() string {
-	out := []string{e.Left.String()}
-	for _, r := range e.Right {
+func (me *MetricExpression) String() string {
+	out := []string{me.Left.String()}
+	for _, r := range me.Right {
 		out = append(out, r.String())
 	}
 	return strings.Join(out, " ")
@@ -190,8 +190,7 @@ func (mep *MetricExpressionParser) Parse(expr string) (*MetricExpression, error)
 	return mep.parser.ParseString("", sanitized)
 }
 
-// Metric Breakdown
-// Convert into formulas
+// MetricExpressionFormula breaks down a query into its formulaic parts
 type MetricExpressionFormula struct {
 	Expressions map[string]string
 	Formula     string

--- a/metricexpression_test.go
+++ b/metricexpression_test.go
@@ -83,11 +83,11 @@ func Test_MetricExpressionFormula(t *testing.T) {
 	}{
 		{
 			name:    "addition formula",
-			query:   "sum:metric.name{foo:bar} + sum:metric.name_two{foo:bar}",
+			query:   "sum:metric.name{foo:bar} + sum:metric.name_two{foo:bar, baz:bang}",
 			formula: "a + b",
 			expressions: map[string]string{
 				"a": "sum:metric.name{foo:bar}",
-				"b": "sum:metric.name_two{foo:bar}",
+				"b": "sum:metric.name_two{foo:bar, baz:bang}",
 			},
 			wantErr:  false,
 			printAST: false,
@@ -99,7 +99,7 @@ func Test_MetricExpressionFormula(t *testing.T) {
 			expressions: map[string]string{
 				"a": "sum:metric.name{foo:bar}",
 				"b": "sum:metric.name_two{foo:bar}",
-				"c": "sum:metric.name_three{}",
+				"c": "sum:metric.name_three{*}",
 			},
 			wantErr:  false,
 			printAST: false,

--- a/metricfilter.go
+++ b/metricfilter.go
@@ -10,30 +10,43 @@ import (
 type MetricFilter struct {
 	Pos lexer.Position
 
-	Parameters []*Param `( @@ ( ("," | "AND" | "and" | "OR" | "or" ) @@ )* | "*" )?`
+	Left       *Param   `@@`
+	Parameters []*Param `( @@* | "*" )`
 }
 
 func (mf *MetricFilter) String() string {
-	if len(mf.Parameters) == 0 {
-		return ""
-	}
+	// if len(mf.Parameters) == 0 &&  {
+	// 	return
+	// }
 
-	params := []string{}
+	params := []string{
+		mf.Left.String(),
+	}
 	for _, v := range mf.Parameters {
 		params = append(params, v.String())
 	}
 
-	return strings.Join(params, ",")
+	return strings.Join(params, "")
 }
 
 type Param struct {
-	GroupedFilter *GroupedFilter `"(" @@ ")"`
-	SimpleFilter  *SimpleFilter  `| @@`
+	GroupedFilter *GroupedFilter        ` "(" @@ ")"`
+	Separator     *FilterValueSeparator `| @@`
+	SimpleFilter  *SimpleFilter         `| @@`
+	Asterisk      bool                  `| @"*"`
 }
 
 func (p *Param) String() string {
+	if p.Separator != nil {
+		return p.Separator.String()
+	}
+
 	if p.GroupedFilter != nil {
 		return p.GroupedFilter.String()
+	}
+
+	if p.Asterisk {
+		return "*"
 	}
 
 	return p.SimpleFilter.String()
@@ -58,7 +71,9 @@ func (sf *SimpleFilter) String() string {
 }
 
 type GroupedFilter struct {
-	Parameters []*Param `( @@ ( ("," | "AND" | "and" | "OR" | "or" ) @@ )* | "*" )?`
+	// Parameters []*Param `( @@ ( ("," | "AND" | "and" | "OR" | "or" ) @@ )* | "*" )?`
+	// Left       *Param   `@@`
+	Parameters []*Param `( @@* | "*" )?`
 }
 
 func (gf *GroupedFilter) String() string {
@@ -67,13 +82,13 @@ func (gf *GroupedFilter) String() string {
 		params = append(params, v.String())
 	}
 
-	return strings.Join(params, ",")
+	return fmt.Sprintf("(%s)", strings.Join(params, ""))
 }
 
 type FilterSeparator struct {
-	Colon bool `@(":" `
-	In    bool `| ("IN" | "in") `
-	NotIn bool `| ("NOT" "IN" | "not" "in") )`
+	Colon bool `@":"`
+	In    bool `| @("IN" | "in") `
+	NotIn bool `| @("NOT" "IN" | "not" "in")`
 }
 
 func (fs *FilterSeparator) String() string {
@@ -103,7 +118,7 @@ func (fk *FilterKey) String() string {
 
 type FilterValue struct {
 	SimpleValue *Value   `	@@`
-	ListValue   []*Value `| ( "(" ( @@ ( "," @@ | "OR" @@ | "or" @@ )* )? ")" )?`
+	ListValue   []*Value `| ( "(" @@* ")" )?`
 }
 
 func (fv *FilterValue) String() string {
@@ -112,20 +127,23 @@ func (fv *FilterValue) String() string {
 		for _, v := range fv.ListValue {
 			strs = append(strs, v.String())
 		}
-		return strings.Join(strs, ",")
+		return fmt.Sprintf("(%s)", strings.Join(strs, ""))
 	}
 
 	return fv.SimpleValue.String()
 }
 
+// TODO: I think this is used multiple places. Need to update
 type Value struct {
-	Boolean    *Bool    `  @("true"|"false")`
-	Identifier *string  `| "!"? @Ident ( @"." @Ident )*`
-	Str        *string  `| @(String)`
-	Number     *float64 `| @(Float|Int)`
+	Separator  *FilterValueSeparator ` @@`
+	Boolean    *Bool                 `|  @("true"|"false")`
+	Identifier *string               `| "!"? @Ident ( @"." @Ident )*`
+	Str        *string               `| @(String)`
+	Number     *float64              `| @(Float|Int)`
 }
 
 func (v *Value) String() string {
+
 	if v.Boolean != nil {
 		return v.Boolean.String()
 	}
@@ -138,5 +156,31 @@ func (v *Value) String() string {
 		return *v.Identifier
 	}
 
+	if v.Separator != nil {
+		return v.Separator.String()
+	}
+
 	return *v.Str
+}
+
+type FilterValueSeparator struct {
+	Comma bool ` @","`
+	And   bool `| @("AND" | "and")`
+	Or    bool `| @("OR" | "or")`
+	In    bool `| @("IN" | "in")`
+}
+
+func (fvs *FilterValueSeparator) String() string {
+	if fvs.Comma {
+		return ", "
+	}
+
+	if fvs.And {
+		return " AND "
+	}
+
+	if fvs.Or {
+		return " OR "
+	}
+	return " IN "
 }

--- a/metricfilter.go
+++ b/metricfilter.go
@@ -127,7 +127,6 @@ func (fv *FilterValue) String() string {
 	return fv.SimpleValue.String()
 }
 
-// TODO: I think this is used multiple places. Need to update
 type Value struct {
 	Separator  *FilterValueSeparator ` @@`
 	Boolean    *Bool                 `|  @("true"|"false")`

--- a/metricfilter.go
+++ b/metricfilter.go
@@ -10,15 +10,11 @@ import (
 type MetricFilter struct {
 	Pos lexer.Position
 
-	Left       *Param   `@@`
-	Parameters []*Param `( @@* | "*" )`
+	Left       *Param   `(@@ | "*" )`
+	Parameters []*Param `( @@* )`
 }
 
 func (mf *MetricFilter) String() string {
-	// if len(mf.Parameters) == 0 &&  {
-	// 	return
-	// }
-
 	params := []string{
 		mf.Left.String(),
 	}
@@ -71,8 +67,6 @@ func (sf *SimpleFilter) String() string {
 }
 
 type GroupedFilter struct {
-	// Parameters []*Param `( @@ ( ("," | "AND" | "and" | "OR" | "or" ) @@ )* | "*" )?`
-	// Left       *Param   `@@`
 	Parameters []*Param `( @@* | "*" )?`
 }
 

--- a/metricfilter_test.go
+++ b/metricfilter_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/alecthomas/participle/v2"
 	"github.com/alecthomas/repr"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,6 +26,24 @@ func Test_MetricMonitorFilter(t *testing.T) {
 		printAST bool // For debugging, can opt in to print AST
 	}{
 		{
+			name:     "test asterisk only",
+			query:    "*",
+			wantErr:  false,
+			printAST: false,
+		},
+		{
+			name:     "test int and string",
+			query:    "code:2xx",
+			wantErr:  false,
+			printAST: false,
+		},
+		{
+			name:     "test one simple filter",
+			query:    "foo:bar-bar",
+			wantErr:  false,
+			printAST: false,
+		},
+		{
 			name:     "test simple comma separated filter",
 			query:    "a:b, c:d",
 			wantErr:  false,
@@ -33,6 +52,12 @@ func Test_MetricMonitorFilter(t *testing.T) {
 		{
 			name:     "test simple AND separated filter",
 			query:    "a:b AND c:d AND e:f",
+			wantErr:  false,
+			printAST: false,
+		},
+		{
+			name:     "test simple OR separated filter",
+			query:    "a:b OR c:d OR e:f",
 			wantErr:  false,
 			printAST: false,
 		},
@@ -73,12 +98,6 @@ func Test_MetricMonitorFilter(t *testing.T) {
 			printAST: false,
 		},
 		{
-			name:     "test lowercase operator suppoer",
-			query:    "a:b and (c:d or e:f) AND g not in (h, i)",
-			wantErr:  false,
-			printAST: false,
-		},
-		{
 			name:     "test example from DataDog docs",
 			query:    "env:shop.ist AND availability-zone IN (us-east-1a, us-east-1b, us-east4-b)",
 			wantErr:  false,
@@ -86,13 +105,7 @@ func Test_MetricMonitorFilter(t *testing.T) {
 		},
 		{
 			name:     "test another example from DataDog docs",
-			query:    "env:prod AND location NOT IN (atlanta,seattle,las-vegas)",
-			wantErr:  false,
-			printAST: false,
-		},
-		{
-			name:     "test int and string",
-			query:    "code:2xx",
+			query:    "env:prod AND location NOT IN (atlanta, seattle, las-vegas)",
 			wantErr:  false,
 			printAST: false,
 		},
@@ -107,6 +120,9 @@ func Test_MetricMonitorFilter(t *testing.T) {
 			if tt.printAST {
 				repr.Println(ast)
 			}
+
+			// Check to make sure we're able to restringify
+			assert.Equal(t, tt.query, ast.String())
 		})
 	}
 }

--- a/metricquery.go
+++ b/metricquery.go
@@ -23,7 +23,7 @@ type Query struct {
 
 	Aggregator string        `parser:"@Ident ':'"`
 	MetricName string        `parser:"@Ident( @'.' @Ident)*"`
-	Filters    *MetricFilter `parser:"'{' @@ '}'"`
+	Filters    *MetricFilter `"{" @@ "}"`
 	By         string        `parser:"Ident?"`
 	Grouping   []string      `parser:"'{'? ( @Ident ( ',' @Ident )* )? '}'?"`
 	Function   []*Function   `parser:"( @@ ( '.' @@ )* )?"`

--- a/metricquery.go
+++ b/metricquery.go
@@ -24,9 +24,9 @@ type Query struct {
 	Aggregator string        `parser:"@Ident ':'"`
 	MetricName string        `parser:"@Ident( @'.' @Ident)*"`
 	Filters    *MetricFilter `parser:"'{' @@ '}'"`
-	By         string        `Ident?`
-	Grouping   []string      `"{"? ( @Ident ( "," @Ident )* )? "}"?`
-	Function   []*Function   `( @@ ( "." @@ )* )?`
+	By         string        `parser:"Ident?"`
+	Grouping   []string      `parser:"'{'? ( @Ident ( ',' @Ident )* )? '}'?"`
+	Function   []*Function   `parser:"( @@ ( '.' @@ )* )?"`
 }
 
 func (q *Query) String() string {

--- a/metricquery_test.go
+++ b/metricquery_test.go
@@ -31,24 +31,24 @@ func Test_MetricQuery(t *testing.T) {
 			wantErr:  true,
 			printAST: false,
 		},
-		// {
-		// 	name:     "filter by asterisk",
-		// 	query:    "sum:namespace.metric.name{ * } by {foo,bar}",
-		// 	wantErr:  false,
-		// 	printAST: false,
-		// },
-		// {
-		// 	name:     "filer by partial asterisk",
-		// 	query:    "sum:namespace.metric.name{foo:bar-*} by {foo,bar}",
-		// 	wantErr:  false,
-		// 	printAST: false,
-		// },
-		// {
-		// 	name:     "test underscores in metric name",
-		// 	query:    "sum:namespace.metric_name{foo:bar} by {baz}",
-		// 	wantErr:  false,
-		// 	printAST: false,
-		// },
+		{
+			name:     "filter by asterisk",
+			query:    "sum:namespace.metric.name{*} by {foo,bar}",
+			wantErr:  false,
+			printAST: false,
+		},
+		{
+			name:     "filer by partial asterisk",
+			query:    "sum:namespace.metric.name{foo:bar-*} by {foo,bar}",
+			wantErr:  false,
+			printAST: false,
+		},
+		{
+			name:     "test underscores in metric name",
+			query:    "sum:namespace.metric_name{foo:bar} by {baz}",
+			wantErr:  false,
+			printAST: false,
+		},
 		{
 			name:     "test hyphens in filters and groupings",
 			query:    "sum:prometheus_metric_source{foo:bar-bar, baz:bang} by {fizz-buzz,bang}",

--- a/metricquery_test.go
+++ b/metricquery_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/alecthomas/repr"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,50 +20,50 @@ func Test_MetricQuery(t *testing.T) {
 		// Simple passing example. Guaranteed to have all parts of a query
 		{
 			name:     "simple query",
-			query:    "sum:namespace.metric.name{foo:bar,baz:bang} by {foo,bar}",
+			query:    "sum:namespace.metric.name{foo:bar} by {foo}",
 			wantErr:  false,
 			printAST: false,
 		},
 		// Simple failing example. Guaranteed to fail because missing the aggregator
 		{
 			name:     "fail due to no aggregator",
-			query:    "namespace.metric.name{foo:bar,baz:bang} by {foo,bar}",
+			query:    "namespace.metric.name{foo:bar, baz:bang} by {foo,bar}",
 			wantErr:  true,
 			printAST: false,
 		},
-		{
-			name:     "filter by asterisk",
-			query:    "sum:namespace.metric.name{*} by {foo,bar}",
-			wantErr:  false,
-			printAST: false,
-		},
-		{
-			name:     "filer by partial asterisk",
-			query:    "sum:namespace.metric.name{foo:bar-*} by {foo,bar}",
-			wantErr:  false,
-			printAST: false,
-		},
-		{
-			name:     "test underscores in metric name",
-			query:    "sum:namespace.metric_name{foo:bar} by {baz}",
-			wantErr:  false,
-			printAST: false,
-		},
+		// {
+		// 	name:     "filter by asterisk",
+		// 	query:    "sum:namespace.metric.name{ * } by {foo,bar}",
+		// 	wantErr:  false,
+		// 	printAST: false,
+		// },
+		// {
+		// 	name:     "filer by partial asterisk",
+		// 	query:    "sum:namespace.metric.name{foo:bar-*} by {foo,bar}",
+		// 	wantErr:  false,
+		// 	printAST: false,
+		// },
+		// {
+		// 	name:     "test underscores in metric name",
+		// 	query:    "sum:namespace.metric_name{foo:bar} by {baz}",
+		// 	wantErr:  false,
+		// 	printAST: false,
+		// },
 		{
 			name:     "test hyphens in filters and groupings",
-			query:    "sum:prometheus_metric_source{foo:bar-bar,baz:bang} by {fizz-buzz,bang}",
+			query:    "sum:prometheus_metric_source{foo:bar-bar, baz:bang} by {fizz-buzz,bang}",
 			wantErr:  false,
 			printAST: false,
 		},
 		{
 			name:     "test numbers in the metric name",
-			query:    "sum:prometheus_metric_source_1{foo:bar-bar,baz:bang} by {fizz-buzz,bang}",
+			query:    "sum:prometheus_metric_source_1{foo:bar-bar, baz:bang} by {fizz-buzz,bang}",
 			wantErr:  false,
 			printAST: false,
 		},
 		{
 			name:     "test numbers in the filters and grouping",
-			query:    "sum:prometheus_metric_source_1{foo:bar-bar-1,baz:bang_2} by {fizz-buzz3,bang}",
+			query:    "sum:prometheus_metric_source_1{foo:bar-bar-1, baz:bang_2} by {fizz-buzz3,bang}",
 			wantErr:  false,
 			printAST: false,
 		},
@@ -80,8 +81,13 @@ func Test_MetricQuery(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			if tt.printAST {
-				repr.Println(ast)
+			// if tt.printAST {
+			repr.Println(ast)
+			// }
+
+			// Check to make sure we're able to restringify
+			if !tt.wantErr {
+				assert.Equal(t, tt.query, ast.String())
 			}
 		})
 	}

--- a/metricquery_test.go
+++ b/metricquery_test.go
@@ -81,9 +81,9 @@ func Test_MetricQuery(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			// if tt.printAST {
-			repr.Println(ast)
-			// }
+			if tt.printAST {
+				repr.Println(ast)
+			}
 
 			// Check to make sure we're able to restringify
 			if !tt.wantErr {


### PR DESCRIPTION
# Purpose

We were parsing `AND|AND NOT|OR|IN|NOT IN` filters but not preserving the separator when re-stringifying the query. This PR fixes that along with some small bug fixes.