### PR TITLE
Fix Bug Using Ints In Metric Expressions

### DIFF
--- a/metricexpression.go
+++ b/metricexpression.go
@@ -27,7 +27,7 @@ func (o *Operator) Capture(s []string) error {
 type ExprValue struct {
 	Subexpression *MetricExpression `  "(" @@ ")"`
 	MetricQuery   *MetricQuery      `| @@`
-	Number        *float64          `|  @(Float|Int)`
+	Number        *float64          `| @Ident`
 }
 
 func (expr *ExprValue) GetQueries() []string {
@@ -45,7 +45,7 @@ func (expr *ExprValue) GetQueries() []string {
 		return strs
 	}
 
-	return []string{fmt.Sprintf("%d", expr.Number)}
+	return []string{}
 }
 
 type Factor struct {

--- a/metricexpression_test.go
+++ b/metricexpression_test.go
@@ -33,7 +33,7 @@ func Test_MetricExpressionCanParse(t *testing.T) {
 		},
 		{
 			name:     "subtraction",
-			query:    "sum:metric.name{foo:bar} - sum:metric.name_two{foo:bar}",
+			query:    "sum:metric.name{foo:bar} - sum:metric.name_two{foo:bar} - 0.1",
 			wantErr:  false,
 			printAST: false,
 		},
@@ -61,6 +61,12 @@ func Test_MetricExpressionCanParse(t *testing.T) {
 			wantErr:  false,
 			printAST: false,
 		},
+		{
+			name:     "parens division with int multiplication",
+			query:    "(sum:metric.name{foo:bar/hello} / sum:metric.name_two{baz:bang}) / 100",
+			wantErr:  false,
+			printAST: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -72,6 +78,9 @@ func Test_MetricExpressionCanParse(t *testing.T) {
 			if tt.printAST {
 				repr.Println(ast)
 			}
+
+			// Assert equal stingification
+			assert.Equal(t, tt.query, ast.String())
 		})
 	}
 }
@@ -109,6 +118,17 @@ func Test_MetricExpressionFormula(t *testing.T) {
 			},
 			wantErr:  false,
 			printAST: false,
+		},
+		{
+			name:    "calculate percent",
+			query:   "(sum:metric.name{foo:bar} / sum:metric.name_two{foo:bar}) * 100",
+			formula: "(a / b) * 100",
+			expressions: map[string]string{
+				"a": "sum:metric.name{foo:bar}",
+				"b": "sum:metric.name_two{foo:bar}",
+			},
+			wantErr:  false,
+			printAST: true,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
# Purpose

Added some use cases around using ints in metric expressions and solved a parsing issue for int values