### PR TITLE
Update/fix "metrics" example

### DIFF
--- a/_examples/metrics/main.go
+++ b/_examples/metrics/main.go
@@ -9,13 +9,13 @@ func main() {
 	metricQueryParser := ddqp.NewMetricQueryParser()
 	metricMonitorParser := ddqp.NewMetricMonitorParser()
 
-	val, err := metricQueryParser.ParseString("", `sum:kubernetes.containers.state.terminated{reason:oomkilled-foo} by    {kube_cluster_name,kube_deployment}`)
+	val, err := metricQueryParser.Parse(`sum:kubernetes.containers.state.terminated{reason:oomkilled-foo} by    {kube_cluster_name,kube_deployment}`)
 	if err != nil {
 		panic(err)
 	}
 	repr.Println(val)
 
-	nextVal, err := metricMonitorParser.ParseString("", `avg(last_5m):max:system.disk.in_use{reason:oomkilled} by {host} < 1.2`)
+	nextVal, err := metricMonitorParser.Parse(`avg(last_5m):max:system.disk.in_use{reason:oomkilled} by {host} < 1.2`)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Came across this library and wanted to run the example. It did not work. The example was using the `ParseString` func which is now called `Parse`.