### PR TITLE
feat: adding a String() function to metric monitors

### DIFF
--- a/metricmonitor.go
+++ b/metricmonitor.go
@@ -1,6 +1,7 @@
 package ddqp
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/alecthomas/participle/v2"
@@ -15,6 +16,11 @@ type MetricMonitor struct {
 	MetricQuery      *MetricQuery `@@`
 	Comparator       string       `@( ">" | ">" "=" | "<" | "<" "=" )`
 	Threshold        float64      `@(Ident)`
+}
+
+// String returns the string representation of the metric monitor.
+func (mm *MetricMonitor) String() string {
+	return fmt.Sprintf("%s(%s):%s %s %g", mm.Aggregation, mm.EvaluationWindow, mm.MetricQuery.String(), mm.Comparator, mm.Threshold)
 }
 
 // NewMetricMonitorParser returns a Parser which is capable of interpretting

--- a/metricmonitor_test.go
+++ b/metricmonitor_test.go
@@ -45,6 +45,10 @@ func Test_MetricMonitor(t *testing.T) {
 			if tt.printAST {
 				repr.Println(ast)
 			}
+
+			// test re-stringification
+			restring := ast.String()
+			require.Equal(t, tt.query, restring)
 		})
 	}
 }


### PR DESCRIPTION
# Purpose

Allows converting a parsed monitor back to a string