### PR TITLE
feat(parser): support slash-prefixed and template variable filter values

### DIFF
--- a/metricfilter_test.go
+++ b/metricfilter_test.go
@@ -312,6 +312,25 @@ func Test_MetricMonitorFilter(t *testing.T) {
 			wantErr:  false,
 			printAST: false,
 		},
+		{
+			name:     "test filter value starting with slash",
+			query:    "path:/health",
+			wantErr:  false,
+			printAST: false,
+		},
+		{
+			name:     "test filter value as template variable with accessor",
+			query:    "env:$env.value",
+			wantErr:  false,
+			printAST: false,
+		},
+		{
+			name:      "test negated slash-prefixed value combined with template variable",
+			query:     "!path:/health AND env:$env.value",
+			wantQuery: "!path:/health AND env:$env.value",
+			wantErr:   false,
+			printAST:  false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/metricquery_test.go
+++ b/metricquery_test.go
@@ -212,6 +212,24 @@ func Test_MetricQuery(t *testing.T) {
 			wantErr:  true,
 			printAST: false,
 		},
+		{
+			name:     "negated filter value starting with slash",
+			query:    "sum:metric.name{!path:/health}",
+			wantErr:  false,
+			printAST: false,
+		},
+		{
+			name:     "filter value as template variable with accessor",
+			query:    "sum:metric.name{env:$env.value}",
+			wantErr:  false,
+			printAST: false,
+		},
+		{
+			name:     "template variable, slash-prefixed negation, group-by, and as_count",
+			query:    "sum:http_server_requests.count{service:some-service,env:$env.value,!path:/health} by {path}.as_count()",
+			wantErr:  false,
+			printAST: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/parser.go
+++ b/parser.go
@@ -12,7 +12,7 @@ var lex = lexer.MustSimple([]lexer.SimpleRule{
 	{"SpaceAggregatorCondition", `v: v[<>=]*([0-9]*[.])?[0-9]+`},
 	{"ComparisonOperator", `:>[=]?|:<[=]?|:~`},
 	{"Ident", `[a-zA-Z0-9_][\w\d\-\*\./]*`},
-	{"FilterIdent", `[*-][\w\d*\-\.\/]+`},
+	{"FilterIdent", `[*/$-][\w\d*\-\.\/]+`},
 	{"Float", `[+-]?([0-9]*[.])?[0-9]+`},
 	{"Int", `\d+`},
 	{"Punct", `[-[!@#$%^&*()+_={}\|:;"'<,>.?\/]|]`},


### PR DESCRIPTION
## Description

The changes add support for [template variables](https://docs.datadoghq.com/dashboards/template_variables/#associated-template-variables) and slashes at the beginning of filters. Parsing panics whenever it encounteres such queries.

Actually it's close to a bug fix as it fixes a panic, but let it be a new feature - support for template variables and slashes at the beginning of filters.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `refactor`: Code refactoring
- [ ] `test`: Test updates
- [ ] `perf`: Performance improvement
- [ ] `chore`: Maintenance/tooling

## Breaking Changes

<!-- Does this PR introduce breaking changes? If yes, describe them -->

- [ ] Yes, this PR contains breaking changes
- [x] No breaking changes

## Related Issues

<!-- Link related issues here -->

Fixes #
Closes #
Related to #

## Testing

<!-- Describe the testing you've done -->

- [x] Tests pass locally
- [x] New tests added (if applicable)
- [x] Linter passes

## Checklist

- [x] Commit messages follow [Conventional Commits](../.github/COMMIT_CONVENTION.md)
- [x] Code follows project style guidelines
- [ ] Documentation updated (if needed)
- [x] All tests passing
